### PR TITLE
Add a basic backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-.*env*
+*.env*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.*env*

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "actix-web",
  "dotenv",
  "env_logger",
+ "once_cell",
  "serde",
  "serde_json",
  "sqlx",

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -328,6 +328,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-run-script"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb2f2ab82e500d180442799e50144144c9c05cb3f2475449e70dabc0ad42d53"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +904,7 @@ version = "0.1.0"
 dependencies = [
  "actix-rt",
  "actix-web",
+ "cargo-run-script",
  "dotenv",
  "env_logger",
  "once_cell",
@@ -1697,6 +1709,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -383,6 +383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,27 +424,27 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -536,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -613,6 +619,9 @@ name = "manifold-backend"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "dotenv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -725,9 +734,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -782,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -826,15 +835,15 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -953,14 +962,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "parking_lot",
  "pin-project-lite",

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -180,7 +180,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -237,6 +237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +256,12 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -285,6 +300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,12 +374,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -360,6 +437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
+ "crypto-bigint",
+ "pem-rfc7468",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,7 +457,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -389,6 +477,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +496,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "flate2"
@@ -423,10 +529,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-intrusive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.11.2",
+]
 
 [[package]]
 name = "futures-sink"
@@ -447,6 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -497,6 +625,27 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -506,6 +655,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -551,6 +706,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,16 +739,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "local-channel"
@@ -622,6 +819,7 @@ dependencies = [
  "dotenv",
  "serde",
  "serde_json",
+ "sqlx",
 ]
 
 [[package]]
@@ -635,6 +833,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -658,6 +862,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,12 +948,37 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -703,6 +1001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +1026,28 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+dependencies = [
+ "der",
+ "pkcs8",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
 
 [[package]]
 name = "pkg-config"
@@ -807,12 +1136,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rsa"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+dependencies = [
+ "byteorder",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "smallvec",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -826,6 +1211,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -874,6 +1269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +1314,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
+dependencies = [
+ "itertools",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8de3b03a925878ed54a954f621e64bf55a3c1bd29652d0d1a17830405350188"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
+dependencies = [
+ "ahash 0.7.6",
+ "atoi",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "digest",
+ "dotenvy",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-util",
+ "generic-array",
+ "hashlink",
+ "hex",
+ "indexmap",
+ "itoa",
+ "libc",
+ "log",
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "rustls",
+ "rustls-pemfile",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "sqlx-rt",
+ "stringprep",
+ "thiserror",
+ "tokio-stream",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "sqlx-core",
+ "sqlx-rt",
+ "syn 1.0.109",
+ "url",
+]
+
+[[package]]
+name = "sqlx-rt"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
+dependencies = [
+ "once_cell",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1454,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -970,11 +1539,34 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1040,6 +1632,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1671,89 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"
@@ -1149,6 +1842,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zstd"

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -87,7 +87,6 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -902,7 +901,6 @@ dependencies = [
 name = "manifold-backend"
 version = "0.1.0"
 dependencies = [
- "actix-rt",
  "actix-web",
  "cargo-run-script",
  "dotenv",

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -327,17 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-run-script"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb2f2ab82e500d180442799e50144144c9c05cb3f2475449e70dabc0ad42d53"
-dependencies = [
- "serde",
- "serde_derive",
- "toml",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,7 +891,6 @@ name = "manifold-backend"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "cargo-run-script",
  "dotenv",
  "env_logger",
  "once_cell",
@@ -1708,15 +1696,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "uuid",
 ]
 
 [[package]]
@@ -1793,6 +1794,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/manifold-backend/Cargo.lock
+++ b/manifold-backend/Cargo.lock
@@ -87,6 +87,7 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -498,6 +499,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +759,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -775,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
 name = "local-channel"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,8 +891,10 @@ dependencies = [
 name = "manifold-backend"
 version = "0.1.0"
 dependencies = [
+ "actix-rt",
  "actix-web",
  "dotenv",
+ "env_logger",
  "serde",
  "serde_json",
  "sqlx",
@@ -858,7 +936,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -936,7 +1014,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -991,7 +1069,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1180,6 +1258,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1325,20 @@ name = "serde"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
 
 [[package]]
 name = "serde_json"
@@ -1468,6 +1574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,7 +1659,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1772,6 +1887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,7 +1907,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1792,13 +1925,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1808,10 +1956,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1820,10 +1980,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1832,16 +2004,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "zeroize"

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -3,11 +3,8 @@ name = "manifold-backend"
 version = "0.1.0"
 edition = "2021"
 
-[package.metadata.scripts]
-
 [dependencies]
 actix-web = "4"
-cargo-run-script = "0.1.0"
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 once_cell = "1.17.1"

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -14,3 +14,4 @@ once_cell = "1.17.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 sqlx = { version = "0.6.3", features = ["runtime-actix-rustls", "mysql", "macros"] }
+uuid = { version = "1.3.1", features = ["v4"] }

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-rt = "2.8.0"
 actix-web = "4"
 dotenv = "0.15.0"
-serde = "1.0.159"
+env_logger = "0.10.0"
+serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
-sqlx = { version = "0.6.3", features = ["runtime-actix-rustls", "mysql"] }
+sqlx = { version = "0.6.3", features = ["runtime-actix-rustls", "mysql", "macros"] }

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-rt = "2.8.0"
 actix-web = "4"
 cargo-run-script = "0.1.0"
 dotenv = "0.15.0"

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -3,7 +3,7 @@ name = "manifold-backend"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.scripts]
 
 [dependencies]
 actix-web = "4"

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -10,6 +10,7 @@ actix-rt = "2.8.0"
 actix-web = "4"
 dotenv = "0.15.0"
 env_logger = "0.10.0"
+once_cell = "1.17.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 sqlx = { version = "0.6.3", features = ["runtime-actix-rustls", "mysql", "macros"] }

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
+dotenv = "0.15.0"
+serde = "1.0.159"
+serde_json = "1.0.95"

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -10,3 +10,4 @@ actix-web = "4"
 dotenv = "0.15.0"
 serde = "1.0.159"
 serde_json = "1.0.95"
+sqlx = { version = "0.6.3", features = ["runtime-actix-rustls", "mysql"] }

--- a/manifold-backend/Cargo.toml
+++ b/manifold-backend/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 actix-rt = "2.8.0"
 actix-web = "4"
+cargo-run-script = "0.1.0"
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 once_cell = "1.17.1"

--- a/manifold-backend/README.md
+++ b/manifold-backend/README.md
@@ -1,0 +1,37 @@
+# Manifold Backend
+
+This is the backend for Manifold.
+
+---
+
+## Style Guide
+
+### Routes
+
+Routes should use `kebab-case` formatting, and should not contain any uppercase characters.
+
+---
+
+## Database
+
+### ID
+
+IDs should be stored as type `binary(16) NOT NULL DEFAULT (uuid_to_bin(uuid(), true)) PRIMARY KEY`
+
+- `binary(16)`: stored as 16 unformatted bytes of data. The other option is to use the type `chars(36)` but that uses
+  UTF8 character encoding, which has a variable byte length for each character, so at minimum the amount of bytes used
+  would be 36 but it could go up to 144 bytes. There may be slightly more overhead with having to transfer UUID string
+  into `binary(16)` and back, but there is a much smaller storage size and indexing speeds are greatly increased.
+- `NOT NULL`: There should never be any entry with an id where the id value is null, especially as the id is used as a
+  primary key.
+- `DEFAULT (uuid_to_bin(uuid(), true))`: Sets so that the `id` field is not required to be set when inserting into the
+  table, as this will automatically generate a correctly encoded id value automatically. You can still provide an id
+  value when inserting though, if that is preferred, you just need to remember to manually call `uuid_to_bin` on the
+  UUID string value, ensuring to pass `true` as the second parameter of the function. The `uuid_to_bin` function
+  converts a UUID string into its binary representation, and there is a related `bin_to_uuid` funcion which can be used
+  to convert the binary representation back into a UUID string. The `uuid` function generates a UUID string. The second
+  value in the `uuid_to_bin` function changes the position of the temporal bits in the UUID, which provides better
+  indexing performance in the database. Ensure that you always pass `true` as the second parameter to either the
+  `uuid_to_bin` or `bin_to_uuid` function.
+- `PRIMARY KEY`: This sets the id as the primary key value of the database. This ensures that each entry in the column
+  is always unique.

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Error> {
     let config = environment::init().await?;
 
     let app_state = AppState {
-        pool: connect_db(&config.db.url).await?,
+        pool: connect_db(&config.db.url, None).await?,
     };
 
     HttpServer::new(move || {

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -1,12 +1,16 @@
 use actix_web::{App, HttpServer};
+use sqlx::mysql;
 use std::env;
 
 #[actix_web::main]
-async fn main() -> std::io::Result<()> {
-    dotenv::from_filename(".env").ok();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv::from_filename(".env")?;
 
-    let url = env::var("DATABASE_URL").expect("DATABASE_URL env var could not be found");
-    println!("{url}");
+    let database_url = env::var("DATABASE_URL")?;
+    let pool = mysql::MySqlPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
 
     HttpServer::new(|| App::new())
         .bind(("127.0.0.1", 8080))?

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -1,9 +1,17 @@
 use actix_web::{App, HttpServer};
+use std::env;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    HttpServer::new(App::new)
+    dotenv::from_filename(".env").ok();
+
+    let url = env::var("DATABASE_URL").expect("DATABASE_URL env var could not be found");
+    println!("{url}");
+
+    HttpServer::new(|| App::new())
         .bind(("127.0.0.1", 8080))?
         .run()
-        .await
+        .await?;
+
+    Ok(())
 }

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Error> {
         App::new()
             .app_data(Data::new(config.db.pool.clone()))
             .service(health_check)
-            .service(messages_scope())
+            .configure(messages_scope)
     })
     .bind((config.server.url.host, config.server.url.port))?
     .run()

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -5,7 +5,7 @@ mod routes;
 mod util;
 
 use routes::health_check::health_check;
-use routes::messages::{add_message, get_messages};
+use routes::messages::messages_scope;
 use util::environment;
 
 type Error = Box<dyn std::error::Error>;
@@ -23,8 +23,7 @@ async fn main() -> Result<(), Error> {
         App::new()
             .app_data(Data::new(config.db.pool.clone()))
             .service(health_check)
-            .service(get_messages)
-            .service(add_message)
+            .service(messages_scope())
     })
     .bind((config.server.url.host, config.server.url.port))?
     .run()

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -1,27 +1,32 @@
-use actix_web::{web::Data, App, HttpServer};
-
 mod models;
 mod routes;
 mod util;
 
+use crate::util::database::connect_db;
+use actix_web::{web::Data, App, HttpServer};
 use routes::health_check::health_check;
 use routes::messages::messages_scope;
+use sqlx::MySqlPool;
 use util::environment;
 
 type Error = Box<dyn std::error::Error>;
+
+#[derive(Clone)]
+struct AppState {
+    pool: MySqlPool,
+}
 
 #[actix_web::main]
 async fn main() -> Result<(), Error> {
     let config = environment::init().await?;
 
-    println!(
-        "{} server started at {}:{}",
-        config.env, config.server.url.host, config.server.url.port
-    );
+    let app_state = AppState {
+        pool: connect_db(&config.db.url).await?,
+    };
 
     HttpServer::new(move || {
         App::new()
-            .app_data(Data::new(config.db.pool.clone()))
+            .app_data(Data::new(app_state.clone()))
             .service(health_check)
             .configure(messages_scope)
     })

--- a/manifold-backend/src/main.rs
+++ b/manifold-backend/src/main.rs
@@ -1,10 +1,11 @@
 use actix_web::{web::Data, App, HttpServer};
 
-mod routes;
-use routes::messages::{add_message, get_messages};
-
 mod models;
+mod routes;
 mod util;
+
+use routes::health_check::health_check;
+use routes::messages::{add_message, get_messages};
 use util::environment;
 
 type Error = Box<dyn std::error::Error>;
@@ -21,6 +22,7 @@ async fn main() -> Result<(), Error> {
     HttpServer::new(move || {
         App::new()
             .app_data(Data::new(config.db.pool.clone()))
+            .service(health_check)
             .service(get_messages)
             .service(add_message)
     })

--- a/manifold-backend/src/models/messages.rs
+++ b/manifold-backend/src/models/messages.rs
@@ -1,8 +1,25 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone)]
+pub struct DbMessage {
+    pub id: Option<String>,
+    pub content: String,
+}
+
+impl From<DbMessage> for Message {
+    fn from(db_message: DbMessage) -> Self {
+        Message {
+            id: db_message
+                .id
+                .expect("ID should never be NULL in the database"),
+            content: db_message.content,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct Message {
-    pub id: i32,
+    pub id: String,
     pub content: String,
 }
 

--- a/manifold-backend/src/models/messages.rs
+++ b/manifold-backend/src/models/messages.rs
@@ -1,17 +1,21 @@
 use serde::{Deserialize, Serialize};
 
+// Model representing a message.
 #[derive(Serialize, Deserialize)]
 pub struct Message {
     pub id: String,
     pub content: String,
 }
 
+// Model representing the value returned from querying a message from the database.
 #[derive(Clone, Serialize)]
 pub struct DbMessage {
     pub id: Option<String>,
     pub content: String,
 }
 
+// Convert DbMessage to Message, failing if the id is None. This should never be the case though as the id value in the
+// database is set to NOT NULL.
 impl From<DbMessage> for Message {
     fn from(db_message: DbMessage) -> Self {
         Message {
@@ -23,6 +27,7 @@ impl From<DbMessage> for Message {
     }
 }
 
+// Model representing the data sent from the frontend to the server.
 #[derive(Serialize, Deserialize)]
 pub struct NewMessage {
     pub content: String,

--- a/manifold-backend/src/models/messages.rs
+++ b/manifold-backend/src/models/messages.rs
@@ -1,6 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
+#[derive(Serialize, Deserialize)]
+pub struct Message {
+    pub id: String,
+    pub content: String,
+}
+
+#[derive(Clone, Serialize)]
 pub struct DbMessage {
     pub id: Option<String>,
     pub content: String,
@@ -15,12 +21,6 @@ impl From<DbMessage> for Message {
             content: db_message.content,
         }
     }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct Message {
-    pub id: String,
-    pub content: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/manifold-backend/src/models/messages.rs
+++ b/manifold-backend/src/models/messages.rs
@@ -6,7 +6,7 @@ pub struct Message {
     pub content: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct NewMessage {
     pub content: String,
 }

--- a/manifold-backend/src/models/messages.rs
+++ b/manifold-backend/src/models/messages.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Message {
+    pub id: i32,
+    pub content: String,
+}
+
+#[derive(Deserialize)]
+pub struct NewMessage {
+    pub content: String,
+}

--- a/manifold-backend/src/models/mod.rs
+++ b/manifold-backend/src/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod messages;

--- a/manifold-backend/src/routes/health_check.rs
+++ b/manifold-backend/src/routes/health_check.rs
@@ -1,0 +1,17 @@
+use actix_web::{get, web, HttpResponse, Responder};
+use sqlx::MySqlPool;
+
+#[get("/health-check")]
+async fn health_check(pool: web::Data<MySqlPool>) -> impl Responder {
+    let connection = pool.acquire().await;
+
+    if let Ok(mut connection) = connection {
+        let result = sqlx::query("SELECT 1").execute(&mut connection).await;
+
+        if result.is_ok() {
+            return HttpResponse::Ok().finish();
+        }
+    }
+
+    HttpResponse::ServiceUnavailable().finish()
+}

--- a/manifold-backend/src/routes/health_check.rs
+++ b/manifold-backend/src/routes/health_check.rs
@@ -15,3 +15,29 @@ async fn health_check(pool: web::Data<MySqlPool>) -> impl Responder {
 
     HttpResponse::ServiceUnavailable().finish()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{util::environment, Error};
+    use actix_web::{http::StatusCode, test, web::Data, App};
+
+    #[actix_web::test]
+    async fn test_health_check() -> Result<(), Error> {
+        let config = environment::init().await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(config.db.pool))
+                .service(health_check),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/health-check").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        Ok(())
+    }
+}

--- a/manifold-backend/src/routes/health_check.rs
+++ b/manifold-backend/src/routes/health_check.rs
@@ -34,8 +34,6 @@ mod tests {
         let req = test::TestRequest::get().uri("/health-check").to_request();
         let res = test::call_service(&app, req).await;
 
-        pool.close().await?;
-
         assert_eq!(res.status(), StatusCode::OK);
 
         Ok(())

--- a/manifold-backend/src/routes/messages.rs
+++ b/manifold-backend/src/routes/messages.rs
@@ -19,7 +19,7 @@ async fn add_message(
     pool: web::Data<MySqlPool>,
     new_message: web::Json<NewMessage>,
 ) -> impl Responder {
-    let result: Result<sqlx::mysql::MySqlQueryResult, sqlx::Error> = sqlx::query_as!(
+    let result = sqlx::query_as!(
         Message,
         "INSERT INTO messages (content) VALUES (?)",
         new_message.content

--- a/manifold-backend/src/routes/messages.rs
+++ b/manifold-backend/src/routes/messages.rs
@@ -1,8 +1,14 @@
-use crate::{models::messages::*, Error};
+use crate::models::messages::*;
 use actix_web::{get, post, web, HttpResponse, Responder};
 use sqlx::MySqlPool;
 
-#[get("/messages")]
+pub fn messages_scope() -> actix_web::Scope {
+    web::scope("/messages")
+        .service(get_messages)
+        .service(add_message)
+}
+
+#[get("/")]
 async fn get_messages(pool: web::Data<MySqlPool>) -> impl Responder {
     let messages = sqlx::query_as!(Message, "SELECT * FROM messages ORDER BY id")
         .fetch_all(pool.as_ref())
@@ -14,7 +20,7 @@ async fn get_messages(pool: web::Data<MySqlPool>) -> impl Responder {
     }
 }
 
-#[post("/messages")]
+#[post("/")]
 async fn add_message(
     pool: web::Data<MySqlPool>,
     new_message: web::Json<NewMessage>,

--- a/manifold-backend/src/routes/messages.rs
+++ b/manifold-backend/src/routes/messages.rs
@@ -2,7 +2,9 @@ use crate::{models::messages::*, AppState};
 use actix_web::{get, post, web, HttpResponse, Responder};
 
 pub fn messages_scope(cfg: &mut web::ServiceConfig) {
-    cfg.service(get_messages).service(add_message);
+    cfg.service(get_messages)
+        .service(get_message)
+        .service(add_message);
 }
 
 #[get("/messages")]
@@ -22,6 +24,24 @@ async fn get_messages(app_state: web::Data<AppState>) -> impl Responder {
 
     match messages {
         Ok(messages) => HttpResponse::Ok().json(messages),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+#[get("/messages/{id}")]
+async fn get_message(app_state: web::Data<AppState>, id: web::Path<String>) -> impl Responder {
+    let message: sqlx::Result<Option<Message>> = sqlx::query_as!(
+        DbMessage,
+        "SELECT BIN_TO_UUID(id, true) as id, content FROM messages WHERE id = UUID_TO_BIN(?, true)",
+        id.into_inner()
+    )
+    .fetch_optional(&app_state.pool)
+    .await
+    .map(|db_message| db_message.map(|db_message| db_message.into()));
+
+    match message {
+        Ok(Some(message)) => HttpResponse::Ok().json(message),
+        Ok(None) => HttpResponse::NotFound().finish(),
         Err(_) => HttpResponse::InternalServerError().finish(),
     }
 }
@@ -49,6 +69,8 @@ mod tests {
     use super::*;
     use crate::{util::tests::TestPool, Error};
     use actix_web::{http::StatusCode, test, web::Data, App};
+    use sqlx::mysql;
+    use uuid::Uuid;
 
     #[actix_web::test]
     async fn test_get_messages() -> Result<(), Error> {
@@ -67,6 +89,74 @@ mod tests {
         let res = test::call_service(&app, req).await;
 
         assert_eq!(res.status(), StatusCode::OK);
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_get_message() -> Result<(), Error> {
+        let pool = TestPool::connect().await?;
+
+        let app_state = AppState { pool: pool.get() };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(app_state.clone()))
+                .service(get_message),
+        )
+        .await;
+
+        let message_id = Uuid::new_v4().to_string();
+        let new_message = NewMessage {
+            content: "Test message".into(),
+        };
+
+        let result: sqlx::Result<mysql::MySqlQueryResult> = sqlx::query!(
+            "INSERT INTO messages (id, content) VALUES (UUID_TO_BIN(?, true), ?)",
+            message_id,
+            new_message.content
+        )
+        .execute(&app_state.pool)
+        .await;
+
+        if result.is_ok() {
+            let req = test::TestRequest::get()
+                .uri(&format!("/messages/{}", message_id))
+                .to_request();
+            let res = test::call_service(&app, req).await;
+
+            assert_eq!(res.status(), StatusCode::OK);
+
+            let message: Message = test::read_body_json(res).await;
+            assert_eq!(message.id, message_id);
+            assert_eq!(message.content, new_message.content);
+
+            return Ok(());
+        }
+
+        Err("Failed to insert value into DB".into())
+    }
+
+    #[actix_web::test]
+    async fn test_get_message_not_found() -> Result<(), Error> {
+        let pool = TestPool::connect().await?;
+
+        let app_state = AppState { pool: pool.get() };
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(app_state.clone()))
+                .service(get_message),
+        )
+        .await;
+
+        let non_existent_id = Uuid::new_v4().to_string();
+        let req = test::TestRequest::get()
+            .uri(&format!("/messages/{}", non_existent_id))
+            .to_request();
+        let res = test::call_service(&app, req).await;
+
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
         Ok(())
     }

--- a/manifold-backend/src/routes/messages.rs
+++ b/manifold-backend/src/routes/messages.rs
@@ -2,13 +2,11 @@ use crate::models::messages::*;
 use actix_web::{get, post, web, HttpResponse, Responder};
 use sqlx::MySqlPool;
 
-pub fn messages_scope() -> actix_web::Scope {
-    web::scope("/messages")
-        .service(get_messages)
-        .service(add_message)
+pub fn messages_scope(cfg: &mut web::ServiceConfig) {
+    cfg.service(get_messages).service(add_message);
 }
 
-#[get("/")]
+#[get("/messages")]
 async fn get_messages(pool: web::Data<MySqlPool>) -> impl Responder {
     let messages = sqlx::query_as!(Message, "SELECT * FROM messages ORDER BY id")
         .fetch_all(pool.as_ref())
@@ -20,7 +18,7 @@ async fn get_messages(pool: web::Data<MySqlPool>) -> impl Responder {
     }
 }
 
-#[post("/")]
+#[post("/messages")]
 async fn add_message(
     pool: web::Data<MySqlPool>,
     new_message: web::Json<NewMessage>,
@@ -36,5 +34,57 @@ async fn add_message(
     match result {
         Ok(_) => HttpResponse::Created().finish(),
         Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{util::environment, Error};
+    use actix_web::{http::StatusCode, test, web::Data, App};
+
+    #[actix_web::test]
+    async fn test_get_messages() -> Result<(), Error> {
+        let config = environment::init().await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(config.db.pool.clone()))
+                .service(get_messages),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        Ok(())
+    }
+
+    #[actix_web::test]
+    async fn test_add_message() -> Result<(), Error> {
+        let config = environment::init().await?;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(config.db.pool.clone()))
+                .service(add_message),
+        )
+        .await;
+
+        let new_message = NewMessage {
+            content: "Test message".into(),
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/")
+            .set_json(&new_message)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        Ok(())
     }
 }

--- a/manifold-backend/src/routes/messages.rs
+++ b/manifold-backend/src/routes/messages.rs
@@ -1,0 +1,34 @@
+use crate::{models::messages::*, Error};
+use actix_web::{get, post, web, HttpResponse, Responder};
+use sqlx::MySqlPool;
+
+#[get("/messages")]
+async fn get_messages(pool: web::Data<MySqlPool>) -> impl Responder {
+    let messages = sqlx::query_as!(Message, "SELECT * FROM messages ORDER BY id")
+        .fetch_all(pool.as_ref())
+        .await;
+
+    match messages {
+        Ok(messages) => HttpResponse::Ok().json(messages),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+#[post("/messages")]
+async fn add_message(
+    pool: web::Data<MySqlPool>,
+    new_message: web::Json<NewMessage>,
+) -> impl Responder {
+    let result: Result<sqlx::mysql::MySqlQueryResult, sqlx::Error> = sqlx::query_as!(
+        Message,
+        "INSERT INTO messages (content) VALUES (?)",
+        new_message.content
+    )
+    .execute(pool.as_ref())
+    .await;
+
+    match result {
+        Ok(_) => HttpResponse::Created().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}

--- a/manifold-backend/src/routes/messages.rs
+++ b/manifold-backend/src/routes/messages.rs
@@ -58,8 +58,6 @@ mod tests {
         let req = test::TestRequest::get().uri("/messages").to_request();
         let res = test::call_service(&app, req).await;
 
-        pool.close().await?;
-
         assert_eq!(res.status(), StatusCode::OK);
 
         Ok(())
@@ -87,8 +85,6 @@ mod tests {
             .set_json(&new_message)
             .to_request();
         let res = test::call_service(&app, req).await;
-
-        pool.close().await?;
 
         assert_eq!(res.status(), StatusCode::CREATED);
 

--- a/manifold-backend/src/routes/mod.rs
+++ b/manifold-backend/src/routes/mod.rs
@@ -1,0 +1,1 @@
+pub mod messages;

--- a/manifold-backend/src/routes/mod.rs
+++ b/manifold-backend/src/routes/mod.rs
@@ -1,1 +1,2 @@
+pub mod health_check;
 pub mod messages;

--- a/manifold-backend/src/util/configuration.rs
+++ b/manifold-backend/src/util/configuration.rs
@@ -1,4 +1,4 @@
-use super::{database::DBPool, url::Url};
+use super::url::Url;
 
 pub struct Configuration {
     pub env: String,
@@ -7,7 +7,7 @@ pub struct Configuration {
 }
 
 pub struct DatabaseConfiguration {
-    pub pool: DBPool,
+    pub url: String,
 }
 
 pub struct ServerConfiguration {

--- a/manifold-backend/src/util/configuration.rs
+++ b/manifold-backend/src/util/configuration.rs
@@ -1,0 +1,15 @@
+use super::{database::DBPool, url::Url};
+
+pub struct Configuration {
+    pub env: String,
+    pub db: DatabaseConfiguration,
+    pub server: ServerConfiguration,
+}
+
+pub struct DatabaseConfiguration {
+    pub pool: DBPool,
+}
+
+pub struct ServerConfiguration {
+    pub url: Url,
+}

--- a/manifold-backend/src/util/database.rs
+++ b/manifold-backend/src/util/database.rs
@@ -1,9 +1,22 @@
 use crate::Error;
 use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
 
-pub async fn connect_db(database_url: &str) -> Result<MySqlPool, Error> {
+pub struct DatabaseConnectionConfig {
+    pub max_connections: u32,
+}
+
+pub async fn connect_db<C>(database_url: &str, config: C) -> Result<MySqlPool, Error>
+where
+    C: Into<Option<DatabaseConnectionConfig>>,
+{
+    let mut max_connections = 10;
+
+    if let Some(config) = config.into() {
+        max_connections = config.max_connections;
+    }
+
     let pool: MySqlPool = MySqlPoolOptions::new()
-        .max_connections(10)
+        .max_connections(max_connections)
         .connect(database_url)
         .await?;
 

--- a/manifold-backend/src/util/database.rs
+++ b/manifold-backend/src/util/database.rs
@@ -1,0 +1,17 @@
+use crate::Error;
+use sqlx::{
+    mysql::{MySql, MySqlPoolOptions},
+    Pool,
+};
+
+pub type DBPool = Pool<MySql>;
+
+pub async fn connect_db() -> Result<DBPool, Error> {
+    let database_url = std::env::var("DATABASE_URL")?;
+    let pool = MySqlPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
+
+    Ok(pool)
+}

--- a/manifold-backend/src/util/database.rs
+++ b/manifold-backend/src/util/database.rs
@@ -1,16 +1,10 @@
 use crate::Error;
-use sqlx::{
-    mysql::{MySql, MySqlPoolOptions},
-    Pool,
-};
+use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
 
-pub type DBPool = Pool<MySql>;
-
-pub async fn connect_db() -> Result<DBPool, Error> {
-    let database_url = std::env::var("DATABASE_URL")?;
-    let pool = MySqlPoolOptions::new()
-        .max_connections(5)
-        .connect(&database_url)
+pub async fn connect_db(database_url: &str) -> Result<MySqlPool, Error> {
+    let pool: MySqlPool = MySqlPoolOptions::new()
+        .max_connections(10)
+        .connect(database_url)
         .await?;
 
     Ok(pool)

--- a/manifold-backend/src/util/environment.rs
+++ b/manifold-backend/src/util/environment.rs
@@ -1,0 +1,74 @@
+use super::{
+    configuration::{Configuration, DatabaseConfiguration, ServerConfiguration},
+    database::connect_db,
+    url::{Url, UrlProtocol},
+};
+use crate::Error;
+use std::{env, fmt::Display};
+
+#[derive(Eq, PartialEq)]
+enum Environment {
+    Production,
+    Development,
+}
+
+impl TryFrom<&str> for Environment {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, self::Error> {
+        match value.to_ascii_lowercase().as_str() {
+            "production" | "prod" => Ok(Environment::Production),
+            "development" | "dev" => Ok(Environment::Development),
+            _ => Err(format!("Invalid environment value: {}", value).into()),
+        }
+    }
+}
+
+impl TryFrom<String> for Environment {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, self::Error> {
+        Environment::try_from(value.as_str())
+    }
+}
+
+impl Display for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Environment::Production => "production",
+            Environment::Development => "development",
+        })
+    }
+}
+
+pub async fn init() -> Result<Configuration, Error> {
+    let environment =
+        Environment::try_from(env::var("ENVIRONMENT").unwrap_or("development".into()))?;
+
+    let mut env_file = ".env.dev";
+
+    match environment {
+        Environment::Development => {
+            env::set_var("RUST_LOG", "debug");
+            env_logger::init();
+        }
+        Environment::Production => env_file = ".env",
+    }
+
+    dotenv::from_filename(env_file)?;
+
+    Ok(Configuration {
+        env: environment.to_string(),
+        db: DatabaseConfiguration {
+            pool: connect_db().await?,
+        },
+        server: ServerConfiguration {
+            url: Url {
+                protocol: UrlProtocol::Http,
+                host: env::var("SERVER_ADDRESS")?,
+                port: env::var("SERVER_PORT")?.parse()?,
+                path: vec![].into(),
+            },
+        },
+    })
+}

--- a/manifold-backend/src/util/environment.rs
+++ b/manifold-backend/src/util/environment.rs
@@ -1,6 +1,5 @@
 use super::{
     configuration::{Configuration, DatabaseConfiguration, ServerConfiguration},
-    database::connect_db,
     url::{Url, UrlProtocol},
 };
 use crate::Error;
@@ -62,7 +61,7 @@ pub async fn init() -> Result<Configuration, Error> {
     Ok(Configuration {
         env: environment.to_string(),
         db: DatabaseConfiguration {
-            pool: connect_db().await?,
+            url: env::var("DATABASE_URL")?,
         },
         server: ServerConfiguration {
             url: Url {

--- a/manifold-backend/src/util/environment.rs
+++ b/manifold-backend/src/util/environment.rs
@@ -45,18 +45,16 @@ pub async fn init() -> Result<Configuration, Error> {
     let environment =
         Environment::try_from(env::var("ENVIRONMENT").unwrap_or("development".into()))?;
 
-    let mut env_file = ".env.dev";
-
     match environment {
         Environment::Development => {
             env::set_var("RUST_LOG", "debug");
             static INIT_LOGGER: Lazy<()> = Lazy::new(env_logger::init);
             let _ = &*INIT_LOGGER;
         }
-        Environment::Production => env_file = ".env",
+        Environment::Production => (),
     }
 
-    dotenv::from_filename(env_file)?;
+    dotenv::dotenv()?;
 
     Ok(Configuration {
         env: environment.to_string(),

--- a/manifold-backend/src/util/environment.rs
+++ b/manifold-backend/src/util/environment.rs
@@ -4,6 +4,7 @@ use super::{
     url::{Url, UrlProtocol},
 };
 use crate::Error;
+use once_cell::sync::Lazy;
 use std::{env, fmt::Display};
 
 #[derive(Eq, PartialEq)]
@@ -50,7 +51,8 @@ pub async fn init() -> Result<Configuration, Error> {
     match environment {
         Environment::Development => {
             env::set_var("RUST_LOG", "debug");
-            env_logger::init();
+            static INIT_LOGGER: Lazy<()> = Lazy::new(env_logger::init);
+            let _ = &*INIT_LOGGER;
         }
         Environment::Production => env_file = ".env",
     }

--- a/manifold-backend/src/util/mod.rs
+++ b/manifold-backend/src/util/mod.rs
@@ -2,3 +2,6 @@ pub mod configuration;
 pub mod database;
 pub mod environment;
 pub mod url;
+
+#[cfg(test)]
+pub mod tests;

--- a/manifold-backend/src/util/mod.rs
+++ b/manifold-backend/src/util/mod.rs
@@ -1,0 +1,4 @@
+pub mod configuration;
+pub mod database;
+pub mod environment;
+pub mod url;

--- a/manifold-backend/src/util/tests.rs
+++ b/manifold-backend/src/util/tests.rs
@@ -1,0 +1,32 @@
+
+use crate::Error;
+use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
+
+pub struct TestPool {
+    pub pool: MySqlPool,
+}
+
+impl TestPool {
+    pub async fn connect() -> Result<Self, Error> {
+        dotenv::from_filename(".env.dev")?;
+
+        let pool = MySqlPoolOptions::new()
+            .max_connections(1)
+            .connect(&std::env::var("DATABASE_URL")?)
+            .await?;
+
+        sqlx::query("BEGIN").execute(&pool).await?;
+
+        Ok(TestPool { pool })
+    }
+
+    pub fn get(&self) -> MySqlPool {
+        self.pool.clone()
+    }
+
+    pub async fn close(&self) -> Result<(), Error> {
+        sqlx::query("ROLLBACK").execute(&self.pool).await?;
+
+        Ok(())
+    }
+}

--- a/manifold-backend/src/util/tests.rs
+++ b/manifold-backend/src/util/tests.rs
@@ -1,5 +1,3 @@
-use std::panic::AssertUnwindSafe;
-
 use crate::Error;
 use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
 

--- a/manifold-backend/src/util/url.rs
+++ b/manifold-backend/src/util/url.rs
@@ -1,0 +1,51 @@
+use std::fmt::Display;
+
+use crate::Error;
+
+pub struct Url {
+    pub protocol: UrlProtocol,
+    pub host: String,
+    pub port: u16,
+    pub path: RouteCollection,
+}
+
+pub enum UrlProtocol {
+    Http,
+    Https,
+}
+
+impl TryFrom<&str> for UrlProtocol {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, self::Error> {
+        match value.to_ascii_lowercase().as_str() {
+            "http" => Ok(UrlProtocol::Http),
+            "https" => Ok(UrlProtocol::Https),
+            _ => Err(format!("Invalid URL protocol: {}", value).into()),
+        }
+    }
+}
+
+impl TryFrom<String> for UrlProtocol {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, self::Error> {
+        UrlProtocol::try_from(value.as_str())
+    }
+}
+
+pub struct RouteCollection {
+    pub routes: Vec<String>,
+}
+
+impl Display for RouteCollection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.routes.join("/").as_str())
+    }
+}
+
+impl From<Vec<String>> for RouteCollection {
+    fn from(value: Vec<String>) -> Self {
+        RouteCollection { routes: value }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:backend": "cd manifold-backend && cargo test",
     "build:client": "cd manifold-client && pnpm run build",
     "build:backend": "cd manifold-backend && cross-env ENVIRONMENT=production cargo build --release",
-    "install-all": "pnpm install && run-p install:*",
+    "postinstall": "run-p install:*",
     "install:client": "cd manifold-client && pnpm install"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev:web": "run-p dev:backend dev:client:web",
     "dev:desktop": "run-p dev:backend dev:client:desktop",
-    "dev:backend": "cd manifold-backend && cargo run",
     "dev:client:web": "cd manifold-client && pnpm run dev:web",
     "dev:client:desktop": "cd manifold-client && pnpm run dev:desktop",
+    "dev:backend": "cd manifold-backend && cargo run",
     "build:client": "cd manifold-client && pnpm run build",
     "build:backend": "cd manifold-backend && cargo build --release",
     "install-all": "run-p install:*",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:client:web": "cd manifold-client && pnpm run dev:web",
     "dev:client:desktop": "cd manifold-client && pnpm run dev:desktop",
     "dev:backend": "cd manifold-backend && cargo run",
+    "test:backend": "cd manifold-backend && cargo test",
     "build:client": "cd manifold-client && pnpm run build",
     "build:backend": "cd manifold-backend && cross-env ENVIRONMENT=production cargo build --release",
     "install-all": "pnpm install && run-p install:*",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "dev:client:desktop": "cd manifold-client && pnpm run dev:desktop",
     "dev:backend": "cd manifold-backend && cargo run",
     "build:client": "cd manifold-client && pnpm run build",
-    "build:backend": "cd manifold-backend && cargo build --release",
-    "install-all": "run-p install:*",
-    "install:root": "pnpm install",
+    "build:backend": "cd manifold-backend && cross-env ENVIRONMENT=production cargo build --release",
+    "install-all": "pnpm install && run-p install:*",
     "install:client": "cd manifold-client && pnpm install"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 devDependencies:
+  cross-env:
+    specifier: ^7.0.3
+    version: 7.0.3
   npm-run-all:
     specifier: ^4.1.5
     version: 4.1.5
@@ -67,6 +70,14 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
+  /cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
+
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -76,6 +87,15 @@ packages:
       semver: 5.7.1
       shebang-command: 1.2.0
       which: 1.3.1
+    dev: true
+
+  /cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
     dev: true
 
   /define-properties@1.2.0:
@@ -455,6 +475,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: true
+
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
@@ -524,9 +549,21 @@ packages:
       shebang-regex: 1.0.0
     dev: true
 
+  /shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: true
+
   /shebang-regex@1.0.0:
     resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
     dev: true
 
   /shell-quote@1.8.0:
@@ -662,6 +699,14 @@ packages:
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+
+  /which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
     hasBin: true
     dependencies:
       isexe: 2.0.0


### PR DESCRIPTION
# Overview
Added a basic/example backend. This was implemented to test using actix web and planetscale, and sets up the general style for how we will construct the backend going forward. We will most likely only keep the /health-check endpoint going forward, but this

# Testing
Set up the required env vars in a .env file and used postman to test the endpoints, confirming that the returned values matched what was expected.