### PR TITLE
Add production docker integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  backend:
+    build: ./manifold-backend
+    ports:
+      - "8000:8000"
+  client:
+    build: ./manifold-client
+    ports:
+      - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   backend:
     build: ./manifold-backend
     ports:
-      - "8000:8000"
+      - "8080:8080"
   client:
     build: ./manifold-client
     ports:

--- a/manifold-backend/.cargo/config.toml
+++ b/manifold-backend/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-w64-mingw32-gcc"

--- a/manifold-backend/.cargo/config.toml
+++ b/manifold-backend/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-linker = "x86_64-w64-mingw32-gcc"

--- a/manifold-backend/.dockerignore
+++ b/manifold-backend/.dockerignore
@@ -1,11 +1,9 @@
 target/
 migrations/
 
-# *.env*
-
 .dockerignore
 dockerfile
 
 .gitignore
+.git/
 *.md
-

--- a/manifold-backend/.dockerignore
+++ b/manifold-backend/.dockerignore
@@ -1,0 +1,11 @@
+target/
+migrations/
+
+# *.env*
+
+.dockerignore
+dockerfile
+
+.gitignore
+*.md
+

--- a/manifold-backend/dockerfile
+++ b/manifold-backend/dockerfile
@@ -1,38 +1,10 @@
-# Use the official Rust image as the base image
-FROM rust:latest AS builder
+# Use the main official rust docker image as the builder
+FROM rust:latest as builder
 
-# Set the working directory
+COPY . /app
+
 WORKDIR /app
 
-# Copy the Rust manifest files
-COPY Cargo.toml Cargo.lock .env ./
+RUN cargo build --release
 
-# Create a dummy source code file to build dependencies
-RUN mkdir src && echo 'fn main() {}' > src/main.rs
-
-# Cache and build dependencies
-RUN cargo build --release --target=x86_64-unknown-linux-gnu
-
-# Remove the dummy source code file
-RUN rm -f src/main.rs
-
-# Copy the actual source code
-COPY src ./src
-
-# Build the project
-RUN cargo build --release --target=x86_64-unknown-linux-gnu
-
-# Runtime image
-FROM debian:buster-slim
-
-# Set the working directory
-WORKDIR /app
-
-# Copy the binary from the builder image
-COPY --from=builder /app/.env /app/target/x86_64-unknown-linux-gnu/release/manifold-backend /app/
-
-# Expose the port the backend listens on
-EXPOSE 8000
-
-# Run the backend
-CMD ["/app/manifold-backend"]
+CMD ["./target/release/manifold-backend"]

--- a/manifold-backend/dockerfile
+++ b/manifold-backend/dockerfile
@@ -5,13 +5,13 @@ FROM rust:latest AS builder
 WORKDIR /app
 
 # Copy the Rust manifest files
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock .env ./
 
 # Create a dummy source code file to build dependencies
 RUN mkdir src && echo 'fn main() {}' > src/main.rs
 
 # Cache and build dependencies
-RUN cargo build --release
+RUN cargo build --release --target=x86_64-unknown-linux-gnu
 
 # Remove the dummy source code file
 RUN rm -f src/main.rs
@@ -20,7 +20,7 @@ RUN rm -f src/main.rs
 COPY src ./src
 
 # Build the project
-RUN cargo build --release
+RUN cargo build --release --target=x86_64-unknown-linux-gnu
 
 # Runtime image
 FROM debian:buster-slim
@@ -29,7 +29,7 @@ FROM debian:buster-slim
 WORKDIR /app
 
 # Copy the binary from the builder image
-COPY --from=builder /app/target/release/manifold-backend /app/
+COPY --from=builder /app/.env /app/target/x86_64-unknown-linux-gnu/release/manifold-backend /app/
 
 # Expose the port the backend listens on
 EXPOSE 8000

--- a/manifold-backend/dockerfile
+++ b/manifold-backend/dockerfile
@@ -1,10 +1,20 @@
-# Use the main official rust docker image as the builder
+# Use the main official rust docker image as the builder image
 FROM rust:latest as builder
 
+# copy source into the docker image
 COPY . /app
-
 WORKDIR /app
 
+# Build the backend
 RUN cargo build --release
 
-CMD ["./target/release/manifold-backend"]
+# Use google distroless image as runtime image
+FROM gcr.io/distroless/cc-debian11
+
+# Copy built backend from builder image
+COPY --from=builder /app/target/release/manifold-backend /app/manifold-backend
+COPY --from=builder /app/.env /app/.env
+WORKDIR /app
+
+# Start the backend
+CMD ["./manifold-backend"]

--- a/manifold-backend/dockerfile
+++ b/manifold-backend/dockerfile
@@ -34,6 +34,19 @@ RUN cargo chef cook --release --recipe-path recipe.json
 FROM rust:latest AS builder
 ARG ENV_FILE
 
+# Creae appuser
+ENV USER=web
+ENV UID=1001
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    "${USER}"
+
 # Copy source into the docker image
 WORKDIR /app
 COPY . .
@@ -54,10 +67,16 @@ RUN cargo build --release
 FROM gcr.io/distroless/cc-debian11
 ARG ENV_FILE
 
+# Import appuser from builder
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
 # Copy built backend from builder image
 WORKDIR /app
 COPY --from=builder /app/target/release/manifold-backend manifold-backend
 COPY --from=builder /app/${ENV_FILE} .env
+
+USER web:web
 
 # Start the backend
 CMD ["./manifold-backend"]

--- a/manifold-backend/dockerfile
+++ b/manifold-backend/dockerfile
@@ -1,0 +1,38 @@
+# Use the official Rust image as the base image
+FROM rust:latest AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the Rust manifest files
+COPY Cargo.toml Cargo.lock ./
+
+# Create a dummy source code file to build dependencies
+RUN mkdir src && echo 'fn main() {}' > src/main.rs
+
+# Cache and build dependencies
+RUN cargo build --release
+
+# Remove the dummy source code file
+RUN rm -f src/main.rs
+
+# Copy the actual source code
+COPY src ./src
+
+# Build the project
+RUN cargo build --release
+
+# Runtime image
+FROM debian:buster-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the binary from the builder image
+COPY --from=builder /app/target/release/manifold-backend /app/
+
+# Expose the port the backend listens on
+EXPOSE 8000
+
+# Run the backend
+CMD ["/app/manifold-backend"]

--- a/manifold-backend/dockerfile
+++ b/manifold-backend/dockerfile
@@ -1,20 +1,63 @@
-# Use the main official rust docker image as the builder image
-FROM rust:latest as builder
+ARG ENV_FILE=.env
 
-# copy source into the docker image
-COPY . /app
+###########################
+## Base cargo-chef Image ##
+###########################
+
+FROM rust:latest AS chef
 WORKDIR /app
+RUN cargo install cargo-chef
+
+###################
+## Planner Image ##
+###################
+
+# Generate a recipe file for dependencies
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+##################
+## Cacher Image ##
+##################
+
+# Build the dependencies
+FROM chef AS cacher
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+###################
+## Builder Image ##
+###################
+
+# Use the main official rust docker image as the builder image
+FROM rust:latest AS builder
+ARG ENV_FILE
+
+# Copy source into the docker image
+WORKDIR /app
+COPY . .
+COPY ${ENV_FILE} .env
+
+# Copy dependencies from cacher image
+COPY --from=cacher /app/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
 # Build the backend
 RUN cargo build --release
 
+###################
+## Runtime Image ##
+###################
+
 # Use google distroless image as runtime image
 FROM gcr.io/distroless/cc-debian11
+ARG ENV_FILE
 
 # Copy built backend from builder image
-COPY --from=builder /app/target/release/manifold-backend /app/manifold-backend
-COPY --from=builder /app/.env /app/.env
 WORKDIR /app
+COPY --from=builder /app/target/release/manifold-backend manifold-backend
+COPY --from=builder /app/${ENV_FILE} .env
 
 # Start the backend
 CMD ["./manifold-backend"]

--- a/manifold-backend/src/util/environment.rs
+++ b/manifold-backend/src/util/environment.rs
@@ -50,11 +50,11 @@ pub async fn init() -> Result<Configuration, Error> {
             env::set_var("RUST_LOG", "debug");
             static INIT_LOGGER: Lazy<()> = Lazy::new(env_logger::init);
             let _ = &*INIT_LOGGER;
+
+            dotenv::dotenv()?;
         }
         Environment::Production => (),
     }
-
-    dotenv::dotenv()?;
 
     Ok(Configuration {
         env: environment,

--- a/manifold-client/dockerfile
+++ b/manifold-client/dockerfile
@@ -1,0 +1,33 @@
+# Use the official Node.js image as the base image
+FROM node:latest AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Install pnpm
+RUN corepack enable
+RUN corepack prepare pnpm@latest --activate
+
+# Copy package.json, pnpm-lock.yaml, and other necessary files
+COPY package.json pnpm-lock.yaml .npmrc ./
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy the source code
+COPY . .
+
+# Build the client
+RUN pnpm run build 2>&1 | tee build_output.log || (cat build_output.log && exit 1)
+
+# Runtime image
+FROM nginx:alpine
+
+# Copy the build output from the builder image
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Expose the port the client listens on
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/manifold-client/package.json
+++ b/manifold-client/package.json
@@ -6,7 +6,7 @@
 		"dev:web": "vite dev --open",
 		"dev:web-background": "vite dev",
 		"dev:desktop": "tauri dev",
-		"build": "run-p build:*",
+		"build": "run-s build:*",
 		"build:web": "vite build",
 		"build:desktop": "tauri build",
 		"preview": "vite preview",


### PR DESCRIPTION
# Summary
Add docker integration for frontend and backend and confirmed that the backend works as expected. The frontend will need to be updated as work begins on the frontend. Currently the backend container will only work with the planetscale database url and not the local mysql database url. This will need to be fixed at a later time.

# Testing
Ran `docker-compose up --build` with the production .env file and confirmed that the backend was working by querying the endpoints in postman.