### PR TITLE
Add user profile table

### DIFF
--- a/backend/migrations/20230511151506_add-users-table.down.sql
+++ b/backend/migrations/20230511151506_add-users-table.down.sql
@@ -1,3 +1,4 @@
 -- Drop created tables.
 DROP TABLE login_identity__email;
+DROP TABLE user_profile;
 DROP TABLE users;

--- a/backend/migrations/20230511151506_add-users-table.up.sql
+++ b/backend/migrations/20230511151506_add-users-table.up.sql
@@ -1,10 +1,22 @@
--- Create users table.
+-- Base user table for essential user data.
 CREATE TABLE users (
   id binary(16) PRIMARY KEY NOT NULL,
 
   username varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL UNIQUE,
-  first_name varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  last_name varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  
+  created_at datetime NOT NULL DEFAULT current_timestamp,
+  updated_at datetime NOT NULL DEFAULT current_timestamp ON UPDATE current_timestamp
+);
+
+-- Table for ancillary user data.
+CREATE TABLE user_profile (
+  user_id binary(16) PRIMARY KEY NOT NULL,
+
+  display_name varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+
+  first_name varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  last_name varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  date_of_birth date NOT NULL,
 
   created_at datetime NOT NULL DEFAULT current_timestamp,
   updated_at datetime NOT NULL DEFAULT current_timestamp ON UPDATE current_timestamp

--- a/backend/src/models/users.rs
+++ b/backend/src/models/users.rs
@@ -22,8 +22,6 @@ pub struct User {
     pub id: Uuid,
 
     pub username: String,
-    pub first_name: Option<String>,
-    pub last_name: Option<String>,
 
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,

--- a/backend/src/util/users.rs
+++ b/backend/src/util/users.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 pub async fn get_user(id: Uuid, db_pool: &MySqlPool) -> Result<Option<User>> {
     let user = sqlx::query_as!(
         User,
-        "SELECT id AS `id: Uuid`, username, first_name, last_name, created_at, updated_at FROM users WHERE id = ?",
+        "SELECT id AS `id: Uuid`, username, created_at, updated_at FROM users WHERE id = ?",
         id
     )
     .fetch_optional(db_pool)
@@ -21,7 +21,7 @@ pub async fn get_user(id: Uuid, db_pool: &MySqlPool) -> Result<Option<User>> {
 pub async fn get_users(db_pool: &MySqlPool) -> Result<Vec<User>> {
     let users = sqlx::query_as!(
         User,
-        "SELECT id AS `id: Uuid`, username, first_name, last_name, created_at, updated_at FROM users ORDER BY id"
+        "SELECT id AS `id: Uuid`, username, created_at, updated_at FROM users ORDER BY id"
     )
     .fetch_all(db_pool)
     .await?;


### PR DESCRIPTION
This adds a new table for ancillary user data, such as a user's display name, first and last names, and their date of birth. This is to separate necessary data from additional data for a user. There have been no routes added for creating or updating a user's profile data. This can be done while doing the UI for it.